### PR TITLE
Fix chat layout and add scrollbar

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -110,7 +110,7 @@ const AIAssistant = () => {
   ];
 
   return (
-    <Card className="h-[600px] flex flex-col">
+    <Card className="h-[70vh] max-h-[80vh] flex flex-col overflow-hidden">
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2">
@@ -134,16 +134,16 @@ const AIAssistant = () => {
         </div>
       </CardHeader>
 
-      <CardContent className="flex-1 flex flex-col">
+      <CardContent className="flex-1 flex flex-col overflow-hidden">
         {/* Messages */}
-        <div className="flex-1 overflow-y-auto space-y-4 mb-4">
+        <div className="flex-1 overflow-y-auto overscroll-contain space-y-4 mb-4 pr-2">
           {messages.map((message) => (
             <div
               key={message.id}
               className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}
             >
               <div
-                className={`max-w-[80%] rounded-lg p-3 ${
+                className={`max-w-[80%] rounded-lg p-3 break-words whitespace-pre-wrap ${
                   message.type === 'user'
                     ? 'bg-kumbh-saffron text-white'
                     : 'bg-accent text-accent-foreground'


### PR DESCRIPTION
Add scrollbar and constrain chat card height to prevent layout overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9694107-d4f0-41c8-b03c-440f4e48c148">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9694107-d4f0-41c8-b03c-440f4e48c148">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

